### PR TITLE
Add annotated reaction counts for posts and comments

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -2,8 +2,8 @@
 
 from django.db import models
 from django.contrib.auth.models import User # Importamos el modelo de usuario de Django
-from django.contrib.contenttypes.fields import GenericForeignKey # Importa GenericForeignKey
-from django.contrib.contenttypes.models import ContentType # ¡Importa ContentType desde aquí!
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation  # Importa GenericForeignKey
+from django.contrib.contenttypes.models import ContentType  # ¡Importa ContentType desde aquí!
 
 
 # Modelo para las publicaciones del blog
@@ -13,6 +13,7 @@ class Post(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='blog_posts') # Relación con el autor (tú)
     created_at = models.DateTimeField(auto_now_add=True) # Fecha y hora de creación (automático)
     updated_at = models.DateTimeField(auto_now=True) # Fecha y hora de última actualización (automático)
+    reactions = GenericRelation('Reaction')
 
     class Meta:
         ordering = ['-created_at'] # Ordenar los posts por fecha de creación descendente
@@ -26,6 +27,7 @@ class Comment(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='blog_comments') # Relación con el autor del comentario
     content = models.TextField() # Contenido del comentario
     created_at = models.DateTimeField(auto_now_add=True) # Fecha y hora de creación (automático)
+    reactions = GenericRelation('Reaction')
 
     class Meta:
         ordering = ['created_at'] # Ordenar los comentarios por fecha de creación ascendente

--- a/blog/serializers.py
+++ b/blog/serializers.py
@@ -3,9 +3,6 @@
 from rest_framework import serializers
 from .models import Post, Comment, Reaction
 from django.contrib.auth.models import User
-# ¡Nuevas importaciones necesarias para manejar GenericRelations!
-from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes.fields import GenericRelation # Puede que no sea estrictamente necesaria aquí si solo accedes, pero es buena práctica
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -15,57 +12,23 @@ class UserSerializer(serializers.ModelSerializer):
 
 class PostSerializer(serializers.ModelSerializer):
     author = UserSerializer(read_only=True)
-    likes_count = serializers.SerializerMethodField()
-    dislikes_count = serializers.SerializerMethodField()
+    likes_count = serializers.IntegerField(read_only=True, default=0)
+    dislikes_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = Post
         fields = ['id', 'title', 'content', 'author', 'created_at', 'updated_at', 'likes_count', 'dislikes_count']
         read_only_fields = ['author']
 
-    def get_likes_count(self, obj):
-        # Accede a las reacciones a través del ContentType del Post y el ID del objeto
-        post_content_type = ContentType.objects.get_for_model(Post)
-        return Reaction.objects.filter(
-            content_type=post_content_type,
-            object_id=obj.id,
-            is_like=True
-        ).count()
-
-    def get_dislikes_count(self, obj):
-        post_content_type = ContentType.objects.get_for_model(Post)
-        return Reaction.objects.filter(
-            content_type=post_content_type,
-            object_id=obj.id,
-            is_like=False
-        ).count()
-
 class CommentSerializer(serializers.ModelSerializer):
     author = UserSerializer(read_only=True)
-    likes_count = serializers.SerializerMethodField()
-    dislikes_count = serializers.SerializerMethodField()
+    likes_count = serializers.IntegerField(read_only=True, default=0)
+    dislikes_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = Comment
         fields = ['id', 'post', 'author', 'content', 'created_at', 'likes_count', 'dislikes_count']
         read_only_fields = ['author']
-
-    def get_likes_count(self, obj):
-        # Accede a las reacciones a través del ContentType del Comment y el ID del objeto
-        comment_content_type = ContentType.objects.get_for_model(Comment)
-        return Reaction.objects.filter(
-            content_type=comment_content_type,
-            object_id=obj.id,
-            is_like=True
-        ).count()
-
-    def get_dislikes_count(self, obj):
-        comment_content_type = ContentType.objects.get_for_model(Comment)
-        return Reaction.objects.filter(
-            content_type=comment_content_type,
-            object_id=obj.id,
-            is_like=False
-        ).count()
 
 class ReactionSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)


### PR DESCRIPTION
## Summary
- Add GenericRelation to Post and Comment to access reactions
- Annotate likes and dislikes counts in PostViewSet and CommentViewSet
- Replace serializer methods with annotated fields to reduce queries

## Testing
- `python manage.py test`
- `python manage.py makemigrations`


------
https://chatgpt.com/codex/tasks/task_e_689ac02115d8832ea62077873f3cb28a