### PR TITLE
Make API base configurable and dynamic content type IDs

### DIFF
--- a/blog/static/blog/html/index.html
+++ b/blog/static/blog/html/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/static/blog/css/style.css">
 </head>
 <body>
-    <div id="app">
+    <div id="app" data-api-base="/api/">
         <header>
             <h1>Blog Privado</h1>
         </header>

--- a/blog/views.py
+++ b/blog/views.py
@@ -2,7 +2,7 @@
 
 from rest_framework import viewsets, permissions, status
 from rest_framework.response import Response
-from rest_framework.decorators import action
+from rest_framework.decorators import action, api_view
 from .models import Post, Comment, Reaction
 from .serializers import PostSerializer, CommentSerializer, ReactionSerializer
 from django.contrib.auth.models import User
@@ -113,3 +113,13 @@ class ReactionViewSet(viewsets.ModelViewSet):
 
     def partial_update(self, request, *args, **kwargs):
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED) # Método no permitido
+
+
+@api_view(['GET'])
+def content_type_ids(request):
+    """Retorna los IDs de ContentType para Post y Comment."""
+    data = {
+        'post': ContentType.objects.get_for_model(Post).id,
+        'comment': ContentType.objects.get_for_model(Comment).id,
+    }
+    return Response(data)

--- a/private_blog_project/urls.py
+++ b/private_blog_project/urls.py
@@ -31,6 +31,7 @@ router.register(r'reactions', blog_views.ReactionViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/content-types/', blog_views.content_type_ids),
     path('api/', include(router.urls)), # Incluye las URLs generadas por el router de DRF
     path('api-auth/', include('rest_framework.urls')), # Opcional: URLs para el login/logout en el navegador de DRF
     path('api/token-auth/', obtain_auth_token), # Endpoint para obtener un token de autenticación


### PR DESCRIPTION
## Summary
- read API base URL from `data-api-base` attribute with fallback `/api/`
- expose post/comment ContentType IDs via new `/api/content-types/` endpoint
- fetch ContentType map on load and send reactions with dynamic IDs

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ac517f1d0832ea56f6ddf0e1504c4